### PR TITLE
conver unaryExpression to updateExpression

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -39,7 +39,7 @@ function objectFromEntriesPlugin({ types: t }) {
                       t.identifier('length'),
                     ),
                   ),
-                  t.unaryExpression('++', t.identifier('k')),
+                  t.updateExpression('++', t.identifier('k')),
 
                   t.BlockStatement([
                     t.variableDeclaration('var', [


### PR DESCRIPTION
They removed the ability to use ++ in unaryExpressions. Changed to updateExpressions.

Reference:
https://github.com/babel/babel/pull/5940

https://babeljs.io/docs/core-packages/babel-types/#updateexpression